### PR TITLE
Deprecating gulp-kitchen-sink

### DIFF
--- a/lib/types/build-config.js
+++ b/lib/types/build-config.js
@@ -27,6 +27,14 @@ const path = require('path');
 const TASK_NAME_SEPARATOR = ':';
 
 
+function ActionConfig(bldConfig, ){
+  this.bldConfig = bldConfig;
+  this.srcSuffixGlobs = [];
+  this.destSuffix = '';
+  this.options = {};
+}
+
+
 
 
 /**

--- a/lib/types/build-config.js
+++ b/lib/types/build-config.js
@@ -27,14 +27,12 @@ const path = require('path');
 const TASK_NAME_SEPARATOR = ':';
 
 
-function ActionConfig(bldConfig, ){
-  this.bldConfig = bldConfig;
-  this.srcSuffixGlobs = [];
-  this.destSuffix = '';
-  this.options = {};
-}
-
-
+// function ActionConfig(bldConfig, ){
+//   this.bldConfig = bldConfig;
+//   this.srcSuffixGlobs = [];
+//   this.destSuffix = '';
+//   this.options = {};
+// }
 
 
 /**


### PR DESCRIPTION
Tying up loose ends to make `master` match `dev`